### PR TITLE
Refactor: let the reporter take anything which can be converted into an Event instead of a raw event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storyteller"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2018"
 
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -12,7 +12,7 @@ pub trait Reporter {
     type Err;
 
     /// Send an event to listeners.
-    fn report_event(&self, event: Self::Event) -> Result<(), Self::Err>;
+    fn report_event(&self, event: impl Into<Self::Event>) -> Result<(), Self::Err>;
 
     /// Request to be disconnected.
     ///

--- a/src/reporter/channel_reporter.rs
+++ b/src/reporter/channel_reporter.rs
@@ -40,9 +40,9 @@ impl<Event> Reporter for ChannelReporter<Event> {
     type Event = Event;
     type Err = ReporterError<Event>;
 
-    fn report_event(&self, event: Self::Event) -> Result<(), Self::Err> {
+    fn report_event(&self, event: impl Into<Self::Event>) -> Result<(), Self::Err> {
         self.message_sender
-            .send(event)
+            .send(event.into())
             .map_err(ReporterError::SendError)
     }
 


### PR DESCRIPTION
…

Changes API of Reporter::report_event to take an impl Into<Self::Event> instead of an Self::Event, for convenience.