### PR TITLE
Breaking: Remove Disconnect Channel in ChannelReporter implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storyteller"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2018"
 
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]
@@ -17,8 +17,6 @@ exclude = ["/.github", "docs/sketches/*.png"]
 default = ["channel_reporter"]
 channel_reporter = ["crossbeam-channel"]
 
-experimental_handle_disconnect_ack = []
-
 [dependencies.crossbeam-channel]
 version = "0.5"
 optional = true
@@ -27,6 +25,9 @@ optional = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 indicatif = "0.16.2"
+
+# parameterized tests
+yare = "1.0.1"
 
 [[example]]
 name = "json_lines"

--- a/src/channel_reporter/channel.rs
+++ b/src/channel_reporter/channel.rs
@@ -1,6 +1,5 @@
 //! Channels which can be used by the `ChannelReporter` and `ChannelEventListener`.
 
-use crate::Disconnect;
 use std::fmt::Formatter;
 use std::{any, fmt};
 
@@ -14,11 +13,17 @@ pub fn event_channel<Event>() -> (EventSender<Event>, EventReceiver<Event>) {
 }
 
 /// A sender, used by `ChannelReporter` and `ChannelEventListener`.
+#[derive(Clone)]
 pub struct EventSender<T>(crossbeam_channel::Sender<T>);
 
 impl<T> EventSender<T> {
     pub fn send(&self, message: T) -> Result<(), EventSendError<T>> {
         self.0.send(message).map_err(|err| EventSendError(err.0))
+    }
+
+    /// When all senders are disconnected, the channel is disconnected
+    pub fn disconnect(self) {
+        drop(self.0)
     }
 }
 
@@ -28,6 +33,12 @@ pub struct EventReceiver<T>(crossbeam_channel::Receiver<T>);
 impl<T> EventReceiver<T> {
     pub fn recv(&self) -> Result<T, EventRecvError> {
         self.0.recv().map_err(|_| EventRecvError)
+    }
+}
+
+impl<T> Clone for EventReceiver<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }
 
@@ -42,38 +53,3 @@ impl<T> fmt::Debug for EventSendError<T> {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct EventRecvError;
-
-// --- Disconnect channel variants
-
-/// A sender, used to communicate Disconnect's between the `ChannelReporter` and `ChannelEventListener`.
-pub struct DisconnectSender(crossbeam_channel::Sender<Disconnect>);
-
-impl DisconnectSender {
-    pub fn acknowledge_disconnection(&self) -> Result<(), DisconnectSendError> {
-        self.0.send(Disconnect).map_err(|_| DisconnectSendError)
-    }
-}
-
-/// A receiver, used to communicate Disconnect's between the `ChannelReporter` and `ChannelEventListener`.
-pub struct DisconnectReceiver(crossbeam_channel::Receiver<Disconnect>);
-
-impl DisconnectReceiver {
-    pub(crate) fn recv(&self) -> Result<Disconnect, DisconnectRecvError> {
-        self.0.recv().map_err(|_| DisconnectRecvError)
-    }
-}
-
-/// A channel used to by the `ChannelEventListener` to acknowledge the disconnection of the `ChannelReporter`.
-///
-/// Allows us to wait
-pub fn disconnect_channel() -> (DisconnectSender, DisconnectReceiver) {
-    let (sender, receiver) = crossbeam_channel::bounded::<Disconnect>(0);
-
-    (DisconnectSender(sender), DisconnectReceiver(receiver))
-}
-
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub struct DisconnectSendError;
-
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub struct DisconnectRecvError;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,12 +1,12 @@
 /// This can be anything, for example a progress bar, a fake reporter which collects events
 /// for testing, a service which sends the events over HTTP, or maybe even a `MultiHandler` which
 /// consists of a `Vec<Box<dyn EventHandler>>` and executes multiple handlers under the hood.
-pub trait EventHandler: Send + 'static {
+pub trait EventHandler: Send + Sync {
     /// The type of event to be handled.
     /// Usually the same type as you would send from a [`Reporter`] to [`Listener`].
     ///
     /// [`Reporter`]: crate::Reporter
-    /// [`Listener`]: crate::Listener
+    /// [`Listener`]: crate::EventListener
     type Event;
 
     /// Act upon some received event.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
 
 mod handler;
 mod listener;
-mod message;
 mod reporter;
 #[cfg(test)]
 mod tests;
@@ -39,12 +38,10 @@ mod channel_reporter;
 
 #[cfg(feature = "channel_reporter")]
 pub use channel_reporter::{
-    channel::disconnect_channel, channel::event_channel, channel::DisconnectReceiver,
-    channel::DisconnectRecvError, channel::DisconnectSender, channel::EventReceiver,
-    channel::EventSendError, channel::EventSender, listener::ChannelEventListener,
-    reporter::ChannelReporter, reporter::ReporterError,
+    channel::event_channel, channel::EventReceiver, channel::EventSendError, channel::EventSender,
+    listener::ChannelEventListener, listener::ChannelFinalizeHandler, reporter::ChannelReporter,
+    reporter::ReporterError,
 };
 pub use handler::EventHandler;
-pub use listener::EventListener;
-pub use message::Disconnect;
+pub use listener::{EventListener, FinishProcessing};
 pub use reporter::Reporter;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,3 +1,0 @@
-/// The disconnect message.
-#[derive(Default, Debug, Copy, Clone)]
-pub struct Disconnect;

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -1,5 +1,3 @@
-use crate::message::Disconnect;
-
 /// A reporter (a type of transmitter) which sends events (the message to be transmitted) to
 /// a listener (a type of receiver).
 pub trait Reporter {
@@ -12,10 +10,8 @@ pub trait Reporter {
     /// Send an event to listeners.
     fn report_event(&self, event: impl Into<Self::Event>) -> Result<(), Self::Err>;
 
-    /// Request to be disconnected.
+    /// Disconnect the reporter from the [`EventListener`].
     ///
-    /// Rendezvous with the listener, allowing it to finish its queue of messages.
-    /// The [`crate::Disconnect`] message will be send by the listener as a
-    /// disconnection acknowledgement.
-    fn disconnect(self) -> Result<Disconnect, Self::Err>;
+    /// [`EventListener`]: crate::EventListener
+    fn disconnect(self) -> Result<(), Self::Err>;
 }

--- a/tests/test_handler.rs
+++ b/tests/test_handler.rs
@@ -1,0 +1,108 @@
+// A sample implementation which collects the events it receives
+#![cfg(feature = "channel_reporter")]
+extern crate core;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use storyteller::{
+    event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
+    FinishProcessing, Reporter,
+};
+
+#[derive(Debug, Eq, PartialEq)]
+struct MyEvent(usize);
+
+// Caution: does only check whether `received` events match expected events
+// Must also use `FinalizeHandler::finish_processing` to ensure panic's are caught.
+struct CollectingHandler {
+    expected_events: Vec<MyEvent>,
+    nth: AtomicUsize,
+}
+
+impl CollectingHandler {
+    fn new(expected: Vec<MyEvent>) -> Self {
+        Self {
+            expected_events: expected,
+            nth: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl EventHandler for CollectingHandler {
+    type Event = MyEvent;
+
+    fn handle(&self, event: Self::Event) {
+        let nth = self.nth.load(Ordering::SeqCst);
+        eprintln!("Test #{}", nth);
+
+        let expected_event = self
+            .expected_events
+            .get(nth)
+            .expect(&format!("No such expected value on index '{}'", nth));
+
+        // compare
+        assert_eq!(expected_event, &event);
+
+        self.nth.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn finish(&self) {
+        let received = self.nth.load(Ordering::SeqCst);
+        let expected = self.expected_events.len();
+
+        if received != expected {
+            panic!(
+                "Received '{}' events, but expected to receive '{}' events",
+                received, expected
+            );
+        }
+    }
+}
+
+#[test]
+fn test() {
+    let (event_sender, event_receiver) = event_channel::<MyEvent>();
+
+    let reporter = ChannelReporter::new(event_sender);
+    let listener = ChannelEventListener::new(event_receiver);
+
+    let handler = CollectingHandler::new(vec![
+        MyEvent(0),
+        MyEvent(1),
+        MyEvent(2),
+        MyEvent(3),
+        MyEvent(4),
+    ]);
+
+    let fin = listener.run_handler(handler);
+
+    for i in 0..5 {
+        reporter.report_event(MyEvent(i)).unwrap();
+    }
+
+    reporter.disconnect().unwrap();
+    fin.finish_processing().unwrap();
+}
+
+#[yare::parameterized(
+    to_few = { vec![ MyEvent(0), MyEvent(1), MyEvent(2), MyEvent(3), MyEvent(4), MyEvent(5)] },
+    to_many = { vec![ MyEvent(0), MyEvent(1), MyEvent(2), MyEvent(3) ] },
+    incorrect = { vec![ MyEvent(0), MyEvent(1), MyEvent(2), MyEvent(3), MyEvent(5), ] },
+)]
+#[should_panic]
+fn expect_failure(expected_events: Vec<MyEvent>) {
+    let (event_sender, event_receiver) = event_channel::<MyEvent>();
+
+    let reporter = ChannelReporter::new(event_sender);
+    let listener = ChannelEventListener::new(event_receiver);
+
+    let handler = CollectingHandler::new(expected_events);
+
+    let fin = listener.run_handler(handler);
+
+    for i in 0..5 {
+        reporter.report_event(MyEvent(i)).unwrap();
+    }
+
+    reporter.disconnect().unwrap();
+    fin.finish_processing().unwrap();
+}


### PR DESCRIPTION
This also makes the crossbeam-channel optional (required just for the channel reporter implementation). Without the channel_reporter features, this crate consists of just the primary traits and it's skeleton, without any ready to use implementation. The channel_reporter feature is enabled by default for ease of getting started.