### PR TITLE
Rename Reporter to EventReporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/foresterre/storyteller/compare/v0.6.1...HEAD
 
+### Changed
+
+* ⚠ Rename `Reporter` and `ReporterError` to `EventReporter` and `EventReporterError` respectively
+
 ## [0.6.1] - 2022-06-19
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,18 @@ msrv = "1.38"
 
 [features]
 default = ["channel_reporter"]
-channel_reporter = ["crossbeam-channel"]
+channel_reporter = ["crossbeam-channel", "once_cell"]
 
 [dependencies.crossbeam-channel]
 version = "0.5"
+optional = true
+
+# Pin the once_cell version to 1.14, to keep the MSRV 1.38; once_cell 1.15 has an MSRV of 1.56.
+# once_cell itself is not directly used by storyteller, but we depend on it down-tree via crossbeam-channel.
+#
+# once_cell changelog: https://github.com/matklad/once_cell/blob/master/CHANGELOG.md#1150
+[dependencies.once_cell]
+version = "~1.14.0"
 optional = true
 
 [dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -5,6 +5,7 @@ confidence-threshold = 0.925
 allow = [
     "Apache-2.0",
     "MIT",
+    "Unicode-DFS-2016",
 ]
 
 [advisories]

--- a/examples/json_lines.rs
+++ b/examples/json_lines.rs
@@ -4,7 +4,9 @@ use std::time::Duration;
 use std::{io, thread};
 use storyteller::{EventHandler, FinishProcessing};
 
-use storyteller::{event_channel, ChannelEventListener, ChannelReporter, EventListener, Reporter};
+use storyteller::{
+    event_channel, ChannelEventListener, ChannelReporter, EventListener, EventReporter,
+};
 
 // See the test function `bar` in src/tests.rs for an example where the handler is a progress bar.
 fn main() {

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use std::{io, thread};
 use storyteller::{
     event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
-    FinishProcessing, Reporter,
+    EventReporter, FinishProcessing,
 };
 
 // --- In the main function, we'll instantiate a Reporter, a Listener, and an EventHandler.

--- a/src/channel_reporter/listener.rs
+++ b/src/channel_reporter/listener.rs
@@ -10,11 +10,11 @@ use std::thread::JoinHandle;
 /// The channel based receiver required to create an instance can be created by calling the
 /// [`event_channel()`] function.
 ///
-/// The [`Reporter`] associated with this event listener is the [`ChannelReporter`].
+/// The [`EventReporter`] associated with this event listener is the [`ChannelReporter`].
 ///
 /// [`ChannelEventListener::run_handler`]: crate::ChannelEventListener::run_handler
 /// [`event_channel()`]: crate::event_channel
-/// [`Reporter`]: crate::Reporter
+/// [`EventReporter`]: crate::EventReporter
 /// [`ChannelReporter`]: crate::ChannelReporter
 pub struct ChannelEventListener<Event> {
     event_receiver: EventReceiver<Event>,
@@ -78,12 +78,12 @@ where
 /// [`FinishProcessing::finish_processing`] will block, since it waits for the thread
 /// to be finished.
 ///
-/// To disconnect the sender channel of the reporter, call [`ChannelReporter::disconnect`].
+/// To disconnect the sender channel of the reporter, call [`disconnect`].
 ///
 /// [`FinishProcessing`]: crate::FinishProcessing
 /// [`EventHandler`]: crate::EventHandler
 /// [`ChannelEventListener`]: crate::ChannelEventListener
-/// [`ChannelReporter::disconnect`]: crate::ChannelReporter::disconnect
+/// [`disconnect`]: crate::EventReporter::disconnect
 #[must_use]
 pub struct ChannelFinalizeHandler {
     handle: JoinHandle<()>,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -3,10 +3,10 @@
 /// consists of a `Vec<Box<dyn EventHandler>>` and executes multiple handlers under the hood.
 pub trait EventHandler: Send + Sync {
     /// The type of event to be handled.
-    /// Usually the same type as you would send from a [`Reporter`] to [`Listener`].
+    /// Usually the same type as you would send from a [`EventReporter`] to [`EventListener`].
     ///
-    /// [`Reporter`]: crate::Reporter
-    /// [`Listener`]: crate::EventListener
+    /// [`EventReporter`]: crate::EventReporter
+    /// [`EventListener`]: crate::EventListener
     type Event;
 
     /// Act upon some received event.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!     which may be asserted on in software tests, or a handler which sends websocket messages
 //!     for each event.
 //!     
-//! * [`Reporter`]: Used to communicate messages to a user.
+//! * [`EventReporter`]: Used to communicate messages to a user.
 //! * [`EventListener`]: Receives the messages, send by a reporter and runs the `EventHandler`
 //!     where appropriate.
 //!
@@ -22,7 +22,7 @@
 //! and the [`ChannelEventListener`].
 //!
 //! [`EventHandler`]: crate::EventHandler
-//! [`Reporter`]: crate::Reporter
+//! [`EventReporter`]: crate::EventReporter
 //! [`EventListener`]: `crate::EventListener`
 //! [`ChannelReporter`]: crate::ChannelReporter
 //! [`ChannelEventListener`]: crate::ChannelEventListener
@@ -40,8 +40,8 @@ mod channel_reporter;
 pub use channel_reporter::{
     channel::event_channel, channel::EventReceiver, channel::EventSendError, channel::EventSender,
     listener::ChannelEventListener, listener::ChannelFinalizeHandler, reporter::ChannelReporter,
-    reporter::ReporterError,
+    reporter::EventReporterError,
 };
 pub use handler::EventHandler;
 pub use listener::{EventListener, FinishProcessing};
-pub use reporter::Reporter;
+pub use reporter::EventReporter;

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,7 +1,7 @@
 use crate::EventHandler;
 use std::sync::Arc;
 
-/// A listener, which listens to events from a [`Reporter`],
+/// A listener, which listens to events from a [`EventReporter`],
 /// and can act upon these events by using an [`EventHandler`].
 ///
 /// You may use the included [`ChannelEventListener`] in combination with the
@@ -12,7 +12,7 @@ use std::sync::Arc;
 /// The listener should not block (you can, for example, spawn a thread to which you can communicate
 /// using a channel).
 ///
-/// [`Reporter`]: crate::Reporter
+/// [`EventReporter`]: crate::EventReporter
 /// [`EventHandler`]: crate::EventHandler
 /// [`ChannelEventListener`]: crate::ChannelEventListener
 /// [`ChannelReporter`]: crate::ChannelReporter
@@ -36,13 +36,13 @@ pub trait EventListener {
 /// If the [`EventListener`] runs the handler in a loop,
 /// then calling the [`FinishProcessing::finish_processing`]
 /// method may cause an infinite loop if it does not contain a way to break out of
-/// this loop. Usually, the [`Reporter::disconnect`] method should provide a way to break
+/// this loop. Usually, the [`EventReporter::disconnect`] method should provide a way to break
 /// out of the loop.
 ///
 /// [`EventListener`]: crate::EventListener
 /// [`EventHandler`]: crate::EventHandler
 /// [`FinishProcessing::finish_processing`]: crate::FinishProcessing::finish_processing
-/// [`Reporter::disconnect`]: crate::Reporter::disconnect
+/// [`EventReporter::disconnect`]: crate::EventReporter::disconnect
 #[must_use]
 pub trait FinishProcessing {
     type Err;

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -1,6 +1,6 @@
 /// A reporter (a type of transmitter) which sends events (the message to be transmitted) to
 /// a listener (a type of receiver).
-pub trait Reporter {
+pub trait EventReporter {
     /// The type of message send from a reporter to some listener.
     type Event;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
-    FinishProcessing, Reporter,
+    EventReporter, FinishProcessing,
 };
 use serde::Serialize;
 use std::io::{Stderr, Write};

--- a/tests/collecting_handler.rs
+++ b/tests/collecting_handler.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use storyteller::{
     event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
-    FinishProcessing, Reporter,
+    EventReporter, FinishProcessing,
 };
 
 #[derive(Debug, Eq, PartialEq)]

--- a/tests/multi_handler.rs
+++ b/tests/multi_handler.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use storyteller::{
     event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
-    FinishProcessing, Reporter,
+    EventReporter, FinishProcessing,
 };
 
 // Caution: does only check whether `received` events match expected events

--- a/tests/registering_handler.rs
+++ b/tests/registering_handler.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use storyteller::{
     event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
-    FinishProcessing, Reporter,
+    EventReporter, FinishProcessing,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
This brings the Reporter in line with the other Event* names, such as the EventListener. It's also more specific by being explicit it's meant to report events.