### PR TITLE
Unpin once_cell dependency and set MSRV to 1.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/foresterre/storyteller/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/foresterre/storyteller/compare/v0.8.0...HEAD
 
+## [0.8.0] - 2022-09-28
+
+### Changed
+
+* `storyteller` MSRV is now 1.56
+
+[0.8.0]: https://github.com/foresterre/storyteller/compare/v0.7.0...v0.8.0
 
 ## [0.7.0] - 2022-09-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,24 +9,14 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/foresterre/storyteller"
 
 exclude = ["/.github", "docs/sketches/*.png"]
-
-[package.metadata]
-msrv = "1.38"
+rust-version = "1.56.1"
 
 [features]
 default = ["channel_reporter"]
-channel_reporter = ["crossbeam-channel", "once_cell"]
+channel_reporter = ["crossbeam-channel"]
 
 [dependencies.crossbeam-channel]
 version = "0.5"
-optional = true
-
-# Pin the once_cell version to 1.14, to keep the MSRV 1.38; once_cell 1.15 has an MSRV of 1.56.
-# once_cell itself is not directly used by storyteller, but we depend on it down-tree via crossbeam-channel.
-#
-# once_cell changelog: https://github.com/matklad/once_cell/blob/master/CHANGELOG.md#1150
-[dependencies.once_cell]
-version = "~1.14.0"
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storyteller"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2018"
 
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/foresterre/storyteller"
 
 exclude = ["/.github", "docs/sketches/*.png"]
-rust-version = "1.56.1"
+rust-version = "1.56"
 
 [features]
 default = ["channel_reporter"]


### PR DESCRIPTION
Pinning once_cell results in problems for dependencies which use once_cell 1.15+.

Users which are served by the MSRV of `1.38`, can use `storyteller` `0.7.0` with once_cell `1.14`.

Users which are okay with an MSRV of `1.56` can use `storyteller` `0.8.0`. No functional changes are made in this release.