### PR TITLE
Require crossbeam version which resolves "RUSTSEC-2025-0024"

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -28,4 +28,4 @@ jobs:
       - name: version_of_cargo_msrv
         run: cargo msrv --version
       - name: run_cargo_msrv
-        run: cargo msrv --ignore-lockfile --output-format json verify -- cargo check
+        run: cargo msrv verify --ignore-lockfile --output-format json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["channel_reporter"]
 channel_reporter = ["crossbeam-channel"]
 
 [dependencies.crossbeam-channel]
-version = "0.5"
+version = "0.5.15"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
ID: RUSTSEC-2025-0024
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0024
   ├ The internal `Channel` type's `Drop` method has a race
     which could, in some circumstances, lead to a double-free.
     This could result in memory corruption.