### PR TITLE
Fix potential deadlocks in the shutdown

### DIFF
--- a/.github/workflows/licenses_and_advisories.yml
+++ b/.github/workflows/licenses_and_advisories.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
       - main
-      - staging # for Bors
-      - trying # for Bors
 jobs:
   licenses_and_advisories:
     name: licenses_and_advisories
@@ -19,5 +17,7 @@ jobs:
 
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
-      - uses: actions/checkout@v6.0.1
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          log-level: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### Added
+
+* `DisconnectToken` type, returned by `disconnect` and required by `join` to enforce correct call ordering at compile
+  time
+* `EventReporter::DisconnectToken` and `HandlerGuard::Token` associated types to support the above
+* `ChannelHandlerGuard::disconnect_and_join` as a one-step shorthand for `disconnect` followed by `join`
+* `ChannelHandlerGuard` now panics on drop if `join` was not called first
+
+### Changed
+
+* ⚠ Renamed `FinishProcessing` trait to `HandlerGuard`
+* ⚠ Renamed `FinishProcessing::finish_processing` to `HandlerGuard::join`. The method now takes a `token` argument of
+  type `Self::Token` (the `DisconnectToken` returned by `disconnect`)
+* ⚠ Renamed `ChannelFinalizeHandler` to `ChannelHandlerGuard`
+* ⚠ Renamed `EventListener::FinishProcessingHandle` associated type to `EventListener::Guard`
+* ⚠ `EventReporter::disconnect` now returns `Result<Self::DisconnectToken, Self::Err>` instead of
+  `Result<(), Self::Err>`
+
+### Removed
+
+* ⚠ Removed `Clone` from `EventSender`
+
 ## [1.0.1] - 2025-05-15
 
 ## Changed
@@ -61,16 +83,20 @@
 
 [0.6.0]: https://github.com/foresterre/bisector/compare/v0.5.0...v0.6.0
 
-
 ## [0.5.0] - 2022-06-16
 
 ### Changed
 
 * ⚠ Remove Disconnect Channel in `ChannelReporter`
-  * Removed all disconnect related types, such as: `Disconnect`, `DisconnectSender`, `DisconnectReceiver`, `disconnect_channel()`
-  * Split process of disconnecting channel and waiting for unfinished events to be processed. The former can be done via `Reporter::disconnect()`, the latter via the new `FinishProcessing::finish_processing()`.  As a result, if  `FinishProcessing::finish_processing()` is not called after `Reporter::disconnect()`, events may go unprocessed.
-    * Caution: if  `FinishProcessing::finish_processing()` is called before **`ChannelReporter::disconnect()`** (in case of the included `ChannelReporter` and `ChannelListener` implementations), the program will hang since the event handling thread will never be finish via the disconnect mechanism.
-  * A `FinishProcessing` implementation is now returned by `EventListener::run_handler`
+    * Removed all disconnect related types, such as: `Disconnect`, `DisconnectSender`, `DisconnectReceiver`,
+      `disconnect_channel()`
+    * Split process of disconnecting channel and waiting for unfinished events to be processed. The former can be done
+      via `Reporter::disconnect()`, the latter via the new `FinishProcessing::finish_processing()`. As a result, if
+      `FinishProcessing::finish_processing()` is not called after `Reporter::disconnect()`, events may go unprocessed.
+        * Caution: if  `FinishProcessing::finish_processing()` is called before **`ChannelReporter::disconnect()`** (in
+          case of the included `ChannelReporter` and `ChannelListener` implementations), the program will hang since the
+          event handling thread will never be finish via the disconnect mechanism.
+    * A `FinishProcessing` implementation is now returned by `EventListener::run_handler`
 
 [0.5.0]: https://github.com/foresterre/bisector/compare/v0.4.0...v0.5.0
 
@@ -78,7 +104,8 @@
 
 ### Changed
 
-* Let the reporter take anything which can be converted into an Event via `impl Into<Reporter::Event>` instead of raw `Reporter::Event` instances.
+* Let the reporter take anything which can be converted into an Event via `impl Into<Reporter::Event>` instead of raw
+  `Reporter::Event` instances.
 
 [0.4.0]: https://github.com/foresterre/bisector/compare/v0.3.2...v0.4.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ name = "collecting_handler"
 required-features = ["channel_reporter"]
 
 [[test]]
+name = "handler_guard"
+required-features = ["channel_reporter"]
+
+[[test]]
 name = "multi_handler"
 required-features = ["channel_reporter"]
 

--- a/deny.toml
+++ b/deny.toml
@@ -94,6 +94,9 @@ allow = [
     "MIT",
     "Unicode-DFS-2016",
 ]
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use storyteller::{EventHandler, FinishProcessing};
+use storyteller::{EventHandler, HandlerGuard};
 
 use storyteller::{
     event_channel, ChannelEventListener, ChannelReporter, EventListener, EventReporter,
@@ -37,6 +37,7 @@ fn main() {
     // This can be anything, for example a progress bar (see src/tests.rs for an example of this),
     // a fake reporter which collects events for testing or maybe even a "MultiHandler<'h>" which
     // consists of a Vec<&'h dyn EventHandler> and executes multiple handlers under the hood.
+    #[allow(clippy::default_constructed_unit_structs)]
     let handler = JsonHandler::default();
 
     // This one is included with the library. It just needs to be hooked up with a channel.
@@ -68,12 +69,11 @@ fn main() {
         thread::sleep(Duration::from_millis(100))
     }
 
-    // Within the ChannelReporter, the sender is dropped, thereby disconnecting the channel
-    // Already sent events can still be processed.
-    let _ = reporter.disconnect();
+    // Disconnect the reporter... already sent events can still be processed by the handler thread.
+    let token = reporter.disconnect().unwrap();
 
-    // To keep the processing of already sent events alive, we block the handler
-    let _ = fin.finish_processing();
+    // Join the handler guard to wait for the handler thread to drain and exit.
+    fin.join(token).unwrap();
 }
 
 static SEED: AtomicU32 = AtomicU32::new(1);

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use std::{io, thread};
 use storyteller::{
     event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
-    EventReporter, FinishProcessing,
+    EventReporter, HandlerGuard,
 };
 
 // --- In the main function, we'll instantiate a Reporter, a Listener, and an EventHandler.
@@ -39,16 +39,16 @@ fn main() {
     //
     //  As described above, it spawns a thread which handles updates, so it won't block.
     let event_handler = Arc::new(handler);
-    let finalize_handler = listener.run_handler(event_handler);
+    let guard = listener.run_handler(event_handler);
 
     // Run your program's logic
     my_programming_logic(&reporter).unwrap();
 
-    // First we disconnect the channel, so the thread which handles the events can be finished.
-    reporter.disconnect().unwrap();
-    // Next, we allow our event handler to finish processing its queue of unprocessed events.
-    // This will block the main thread, until all unprocessed events are processed.
-    finalize_handler.finish_processing().unwrap();
+    // Disconnect the channel. This consumes the reporter and returns a disconnect token.
+    let token = reporter.disconnect().unwrap();
+    // Join the guard. The token ensures disconnect was called first, so the handler
+    // thread is guaranteed to exit. Blocks until all queued events are processed.
+    guard.join(token).unwrap();
 }
 
 fn my_programming_logic(reporter: &ChannelReporter<ExampleEvent>) -> Result<(), Box<dyn Error>> {

--- a/src/channel_reporter/channel.rs
+++ b/src/channel_reporter/channel.rs
@@ -13,7 +13,6 @@ pub fn event_channel<Event>() -> (EventSender<Event>, EventReceiver<Event>) {
 }
 
 /// A sender, used by `ChannelReporter` and `ChannelEventListener`.
-#[derive(Clone)]
 pub struct EventSender<T>(crossbeam_channel::Sender<T>);
 
 impl<T> EventSender<T> {

--- a/src/channel_reporter/listener.rs
+++ b/src/channel_reporter/listener.rs
@@ -1,4 +1,6 @@
-use crate::listener::FinishProcessing;
+use crate::channel_reporter::reporter::{ChannelReporter, DisconnectToken, EventReporterError};
+use crate::listener::HandlerGuard;
+use crate::reporter::EventReporter;
 use crate::{EventHandler, EventListener, EventReceiver};
 use std::sync::Arc;
 use std::thread;
@@ -37,68 +39,99 @@ where
     Event: Send + 'static,
 {
     type Event = Event;
-    type FinishProcessingHandle = ChannelFinalizeHandler;
+    type Guard = ChannelHandlerGuard;
 
-    fn run_handler<H>(&self, handler: Arc<H>) -> Self::FinishProcessingHandle
+    fn run_handler<H>(&self, handler: Arc<H>) -> Self::Guard
     where
         H: EventHandler<Event = Self::Event> + 'static,
     {
         let event_receiver = self.event_receiver.clone();
 
-        let handle = thread::spawn(move || {
-            //
-            'evl: loop {
-                match event_receiver.recv() {
-                    Ok(message) => handler.handle(message),
-                    Err(_disconnect) => {
-                        handler.finish();
-                        break 'evl;
-                    }
+        let handle = thread::spawn(move || 'evl: loop {
+            match event_receiver.recv() {
+                Ok(message) => handler.handle(message),
+                Err(_disconnect) => {
+                    handler.finish();
+                    break 'evl;
                 }
             }
         });
 
-        ChannelFinalizeHandler::new(handle)
+        ChannelHandlerGuard::new(handle)
     }
 }
 
-/// A [`FinishProcessing`] implementation for the [`ChannelEventListener`].
-/// Used to wait for the [`EventHandler`] ran by the `listener` to finish processing
-/// events.
+/// A [`HandlerGuard`] for the [`ChannelEventListener`].
 ///
-/// ### Caution: Infinite looping
+/// Holds the handler thread and allows waiting for it to finish via [`HandlerGuard::join`].
 ///
-/// Calling [`FinishProcessing::finish_processing`] without first disconnecting
-/// the sender channel of the reporter will cause the program to be stuck in an infinite
-/// loop.
+/// ### Ordering
 ///
-/// The reason for this is that disconnecting the channel causes the loop to process
-/// a disconnect event, where we break out of the loop. If this disconnect does not
-/// happen, the thread processing events will not be finished, and
-/// [`FinishProcessing::finish_processing`] will block, since it waits for the thread
-/// to be finished.
+/// [`HandlerGuard::join`] requires a [`DisconnectToken`] proof token produced by
+/// [`ChannelReporter::disconnect`]. This enforces that at compile time that the reporter is
+/// disconnected before joining the handler thread. Calling them in the wrong order is a
+/// compile error iso a silent deadlock.
 ///
-/// To disconnect the sender channel of the reporter, call [`disconnect`].
+/// ### Drop behaviour
 ///
-/// [`FinishProcessing`]: crate::FinishProcessing
-/// [`EventHandler`]: crate::EventHandler
+/// Dropping this guard without calling [`join`] is a programming error and will panic
+/// (unless the thread is already unwinding).
+///
+/// [`HandlerGuard`]: crate::HandlerGuard
+/// [`HandlerGuard::join`]: crate::HandlerGuard::join
 /// [`ChannelEventListener`]: crate::ChannelEventListener
-/// [`disconnect`]: crate::EventReporter::disconnect
+/// [`ChannelReporter::disconnect`]: crate::ChannelReporter::disconnect
+/// [`join`]: HandlerGuard::join
 #[must_use]
-pub struct ChannelFinalizeHandler {
-    handle: JoinHandle<()>,
+pub struct ChannelHandlerGuard {
+    handle: Option<JoinHandle<()>>,
 }
 
-impl ChannelFinalizeHandler {
+impl ChannelHandlerGuard {
     fn new(handle: JoinHandle<()>) -> Self {
-        Self { handle }
+        Self {
+            handle: Some(handle),
+        }
     }
 }
 
-impl FinishProcessing for ChannelFinalizeHandler {
-    type Err = ();
+impl ChannelHandlerGuard {
+    /// Disconnect the reporter and join the handler guard in one step.
+    ///
+    /// This is a shorthand for:
+    ///
+    /// ```ignore
+    /// let token = reporter.disconnect()?;
+    /// guard.join(token)?;
+    /// ```
+    ///
+    /// If the handler thread panicked, the panic is re-raised in the calling thread.
+    pub fn disconnect_and_join<Event: Send>(
+        self,
+        reporter: ChannelReporter<Event>,
+    ) -> Result<(), EventReporterError<Event>> {
+        let token = reporter.disconnect()?;
+        self.join(token).expect("handler thread panicked");
+        Ok(())
+    }
+}
 
-    fn finish_processing(self) -> Result<(), Self::Err> {
-        self.handle.join().map_err(|_| ())
+impl HandlerGuard for ChannelHandlerGuard {
+    type Err = ();
+    type Token = DisconnectToken;
+
+    fn join(mut self, _token: DisconnectToken) -> Result<(), Self::Err> {
+        self.handle.take().unwrap().join().map_err(|_| ())
+    }
+}
+
+impl Drop for ChannelHandlerGuard {
+    fn drop(&mut self) {
+        if self.handle.is_some() && !thread::panicking() {
+            panic!(
+                "ChannelHandlerGuard dropped without calling join(). \
+                 Call reporter.disconnect() then guard.join(token) before dropping"
+            );
+        }
     }
 }

--- a/src/channel_reporter/reporter.rs
+++ b/src/channel_reporter/reporter.rs
@@ -2,11 +2,21 @@ use crate::{EventReporter, EventSender};
 use std::error;
 use std::fmt::{Debug, Display, Formatter};
 
+/// Proof that a [`ChannelReporter`] has been disconnected.
+///
+/// Produced by [`ChannelReporter::disconnect`] and consumed by
+/// [`ChannelHandlerGuard::join`]. Because the inner field is private
+/// and this type has no public constructor, the only way to obtain a `DisconnectToken` value
+/// is by calling [`ChannelReporter::disconnect`], which should guarantee correct ordering.
+///
+/// [`ChannelHandlerGuard::join`]: crate::ChannelHandlerGuard::join
+pub struct DisconnectToken(());
+
 /// A specialized type of reporter which uses a channel to transmit messages.
 ///
 /// Use [`EventReporter::disconnect`] to disconnect the channel by dropping the `sender`.
-/// If you want to finish up processing unprocessed events, you may do so by calling
-/// the blocking [`FinishProcessing::finish_processing`].
+/// This returns a [`DisconnectToken`] proof token which must be passed to
+/// [`HandlerGuard::join`] to wait for the handler thread to drain and exit.
 ///
 /// The channel sender (and channel receiver for the `listener`), required to create a
 /// `ChannelReporter` instance can be created by calling the [`event_channel()`]
@@ -15,7 +25,7 @@ use std::fmt::{Debug, Display, Formatter};
 /// The [`EventListener`] associated with this reporter is the [`ChannelEventListener`].
 ///
 /// [`EventReporter::disconnect`]: crate::EventReporter::disconnect
-/// [`FinishProcessing::finish_processing`]: crate::FinishProcessing::finish_processing
+/// [`HandlerGuard::join`]: crate::HandlerGuard::join
 /// [`event_channel()`]: crate::event_channel()
 /// [`EventListener`]: crate::EventListener
 /// [`ChannelEventListener`]: crate::ChannelEventListener
@@ -36,6 +46,7 @@ impl<Event> ChannelReporter<Event> {
 impl<Event> EventReporter for ChannelReporter<Event> {
     type Event = Event;
     type Err = EventReporterError<Event>;
+    type DisconnectToken = DisconnectToken;
 
     fn report_event(&self, event: impl Into<Self::Event>) -> Result<(), Self::Err> {
         self.event_sender
@@ -43,10 +54,15 @@ impl<Event> EventReporter for ChannelReporter<Event> {
             .map_err(EventReporterError::SendError)
     }
 
-    /// Disconnect the sender.
-    #[allow(clippy::unit_arg)]
-    fn disconnect(self) -> Result<(), Self::Err> {
-        Ok(self.event_sender.disconnect())
+    /// Disconnect the sender, returning a [`DisconnectToken`] token.
+    ///
+    /// Pass the token to [`HandlerGuard::join`] to wait for the handler thread to finish
+    /// draining the queue. The token enforces that this call happens first.
+    ///
+    /// [`HandlerGuard::join`]: crate::HandlerGuard::join
+    fn disconnect(self) -> Result<DisconnectToken, Self::Err> {
+        self.event_sender.disconnect();
+        Ok(DisconnectToken(()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,13 @@
 //!
 //! The three building blocks are:
 //! * [`EventHandler`]: The event handler receives an event (our message type) as input,
-//!     and decides what to do with this message. Examples include a json-lines handler which
-//!     prints events to to stderr, a progress bar, a faked handler which collects events for
-//!     which may be asserted on in software tests, or a handler which sends websocket messages
-//!     for each event.
+//!   and decides what to do with this message. Examples include a json-lines handler which
+//!   prints events to stderr, a progress bar, a faked handler which collects events for
+//!   which may be asserted on in software tests, or a handler which sends websocket messages
+//!   for each event.
 //!     
 //! * [`EventReporter`]: Used to communicate messages to a user.
-//! * [`EventListener`]: Receives the messages, send by a reporter and runs the `EventHandler`
-//!     where appropriate.
+//! * [`EventListener`]: Receives the messages, send by a reporter and runs the `EventHandler` where appropriate.
 //!
 //! On top of these building blocks, a channel based implementation is provided which runs the `EventHandler`
 //! in a separate thread.
@@ -39,9 +38,9 @@ mod channel_reporter;
 #[cfg(feature = "channel_reporter")]
 pub use channel_reporter::{
     channel::event_channel, channel::EventReceiver, channel::EventSendError, channel::EventSender,
-    listener::ChannelEventListener, listener::ChannelFinalizeHandler, reporter::ChannelReporter,
-    reporter::EventReporterError,
+    listener::ChannelEventListener, listener::ChannelHandlerGuard, reporter::ChannelReporter,
+    reporter::DisconnectToken, reporter::EventReporterError,
 };
 pub use handler::EventHandler;
-pub use listener::{EventListener, FinishProcessing};
+pub use listener::{EventListener, HandlerGuard};
 pub use reporter::EventReporter;

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -20,37 +20,56 @@ pub trait EventListener {
     /// The type of message send from a reporter to some listener.
     type Event;
 
-    /// Can be used to stop running the event handler.
-    type FinishProcessingHandle: FinishProcessing;
+    /// A guard that keeps the handler running and can be used to wait for it to finish.
+    type Guard: HandlerGuard;
 
-    fn run_handler<H>(&self, handler: Arc<H>) -> Self::FinishProcessingHandle
+    fn run_handler<H>(&self, handler: Arc<H>) -> Self::Guard
     where
         H: EventHandler<Event = Self::Event> + 'static;
 }
 
-/// Provides a way for to wait for [`EventListener`] instances to let their [`EventHandler`] instances
-/// finish up on processing their received events.
+/// A guard over a running [`EventHandler`].
 ///
-/// ### Caution: Infinite looping
+/// Returned by [`EventListener::run_handler`] and held until the caller is ready to wait
+/// for the handler to finish processing all queued events.
 ///
-/// If the [`EventListener`] runs the handler in a loop,
-/// then calling the [`FinishProcessing::finish_processing`]
-/// method may cause an infinite loop if it does not contain a way to break out of
-/// this loop. Usually, the [`EventReporter::disconnect`] method should provide a way to break
-/// out of the loop.
+/// ### Ordering: call [`EventReporter::disconnect`] first
+///
+/// If the [`EventListener`] runs the handler in a loop, calling [`HandlerGuard::join`]
+/// without first disconnecting the reporter will cause an infinite loop (or deadlock),
+/// because the loop only exits when the channel is disconnected.
+///
+/// The [`Self::Token`] associated type enforces correct ordering at compile time. The proof
+/// value can only be obtained by calling [`EventReporter::disconnect`], so passing it here
+/// guarantees the disconnect happened first.
+///
+/// For implementations that have no ordering requirement, you can use `type Token = ()`.
 ///
 /// [`EventListener`]: crate::EventListener
 /// [`EventHandler`]: crate::EventHandler
-/// [`FinishProcessing::finish_processing`]: crate::FinishProcessing::finish_processing
+/// [`HandlerGuard::join`]: crate::HandlerGuard::join
 /// [`EventReporter::disconnect`]: crate::EventReporter::disconnect
 #[must_use]
-pub trait FinishProcessing {
+pub trait HandlerGuard {
     type Err;
 
-    /// Finish up processing of received events.
+    /// A typed proof that the associated [`EventReporter`] has been disconnected.
     ///
-    /// See [`FinishProcessing`] for more.
+    /// For implementations backed by a channel (where disconnect ordering matters), this is
+    /// the [`EventReporter::DisconnectToken`] token returned by [`EventReporter::disconnect`].
     ///
-    /// [`FinishProcessing`]: crate::FinishProcessing
-    fn finish_processing(self) -> Result<(), Self::Err>;
+    /// Implementations with no ordering requirement can just use `type Token = ()`.
+    ///
+    /// [`EventReporter`]: crate::EventReporter
+    /// [`EventReporter::DisconnectToken`]: crate::EventReporter::DisconnectToken
+    /// [`EventReporter::disconnect`]: crate::EventReporter::disconnect
+    type Token;
+
+    /// Wait for the handler to finish processing all queued events.
+    ///
+    /// `token` must be the [`Self::Token`] value produced by [`EventReporter::disconnect`].
+    /// This guarantees the reporter was disconnected before this method is called.
+    ///
+    /// [`EventReporter::disconnect`]: crate::EventReporter::disconnect
+    fn join(self, token: Self::Token) -> Result<(), Self::Err>;
 }

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -7,11 +7,31 @@ pub trait EventReporter {
     /// The type of error which will occur in case of a failure to report an event.
     type Err;
 
+    /// Guarantees that this reporter has been disconnected.
+    ///
+    /// Returned by [`disconnect`] and required by [`HandlerGuard::join`].
+    /// Holding this value is a compile-time proof that [`disconnect`] has already been called,
+    /// which allows [`HandlerGuard::join`] to enforce correct ordering and avoid a deadlock.
+    ///
+    /// [`disconnect`]: EventReporter::disconnect
+    /// [`HandlerGuard::join`]: crate::HandlerGuard::join
+    type DisconnectToken;
+
     /// Send an event to listeners.
     fn report_event(&self, event: impl Into<Self::Event>) -> Result<(), Self::Err>;
 
-    /// Disconnect the reporter from the [`EventListener`].
+    /// Disconnect the reporter from the [`EventListener`], returning a proof-of-disconnect
+    /// token.
+    ///
+    /// Pass the returned [`Self::DisconnectToken`] token to [`HandlerGuard::join`] to wait for
+    /// the handler to finish processing queued events.
+    ///
+    /// # Ordering
+    ///
+    /// `disconnect` mustr be called before calling [`HandlerGuard::join`], which is
+    /// enforced by the `token` at compile time.
     ///
     /// [`EventListener`]: crate::EventListener
-    fn disconnect(self) -> Result<(), Self::Err>;
+    /// [`HandlerGuard::join`]: crate::HandlerGuard::join
+    fn disconnect(self) -> Result<Self::DisconnectToken, Self::Err>;
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
-    EventReporter, FinishProcessing,
+    EventReporter, HandlerGuard,
 };
 use serde::Serialize;
 use std::io::{Stderr, Write};
@@ -139,8 +139,8 @@ fn bar() {
     reporter.report_event(ExampleEvent::event(MyEvent::Increment));
     reporter.report_event(ExampleEvent::text("[status]\t\tFour"));
 
-    reporter.disconnect().unwrap();
-    finalize_handle.finish_processing().unwrap();
+    let token = reporter.disconnect().unwrap();
+    finalize_handle.join(token).unwrap();
 }
 
 #[test]
@@ -171,6 +171,6 @@ fn json() {
     reporter.report_event(ExampleEvent::event(MyEvent::Increment));
     reporter.report_event(ExampleEvent::text("[status]\t\tFour"));
 
-    reporter.disconnect().unwrap();
-    finalize_handle.finish_processing().unwrap();
+    let token = reporter.disconnect().unwrap();
+    finalize_handle.join(token).unwrap();
 }

--- a/tests/collecting_handler.rs
+++ b/tests/collecting_handler.rs
@@ -5,14 +5,14 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use storyteller::{
     event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
-    EventReporter, FinishProcessing,
+    EventReporter, HandlerGuard,
 };
 
 #[derive(Debug, Eq, PartialEq)]
 struct MyEvent(usize);
 
 // Caution: does only check whether `received` events match expected events
-// Must also use `FinalizeHandler::finish_processing` to ensure panic's are caught.
+// Must also use `ChannelHandlerGuard::join` to ensure panic's are caught.
 struct CollectingHandler {
     expected_events: Vec<MyEvent>,
     nth: AtomicUsize,
@@ -79,8 +79,8 @@ fn test() {
         reporter.report_event(MyEvent(i)).unwrap();
     }
 
-    reporter.disconnect().unwrap();
-    fin.finish_processing().unwrap();
+    let token = reporter.disconnect().unwrap();
+    fin.join(token).unwrap();
 }
 
 #[yare::parameterized(
@@ -103,6 +103,6 @@ fn expect_failure(expected_events: Vec<MyEvent>) {
         reporter.report_event(MyEvent(i)).unwrap();
     }
 
-    reporter.disconnect().unwrap();
-    fin.finish_processing().unwrap();
+    let token = reporter.disconnect().unwrap();
+    fin.join(token).unwrap();
 }

--- a/tests/handler_guard.rs
+++ b/tests/handler_guard.rs
@@ -1,0 +1,100 @@
+extern crate core;
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use storyteller::{
+    event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
+    EventReporter, HandlerGuard,
+};
+
+#[derive(Debug, Eq, PartialEq)]
+struct MyEvent(usize);
+
+struct NoopHandler;
+
+impl EventHandler for NoopHandler {
+    type Event = MyEvent;
+    fn handle(&self, _: Self::Event) {}
+}
+
+struct TrackingHandler {
+    handled: AtomicUsize,
+    finished: AtomicBool,
+}
+
+impl TrackingHandler {
+    fn new() -> Self {
+        Self {
+            handled: AtomicUsize::new(0),
+            finished: AtomicBool::new(false),
+        }
+    }
+
+    fn handled(&self) -> usize {
+        self.handled.load(Ordering::SeqCst)
+    }
+
+    fn finished(&self) -> bool {
+        self.finished.load(Ordering::SeqCst)
+    }
+}
+
+impl EventHandler for TrackingHandler {
+    type Event = MyEvent;
+
+    fn handle(&self, _: Self::Event) {
+        self.handled.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn finish(&self) {
+        self.finished.store(true, Ordering::SeqCst);
+    }
+}
+
+#[test]
+#[should_panic]
+fn drop_without_join_panics() {
+    let (sender, receiver) = event_channel::<MyEvent>();
+    let reporter = ChannelReporter::new(sender);
+    let listener = ChannelEventListener::new(receiver);
+    let guard = listener.run_handler(Arc::new(NoopHandler));
+    let token = reporter.disconnect().unwrap();
+    drop(token);
+    drop(guard);
+}
+
+#[test]
+fn finish_called_with_no_events() {
+    let (sender, receiver) = event_channel::<MyEvent>();
+    let reporter = ChannelReporter::new(sender);
+    let listener = ChannelEventListener::new(receiver);
+    let handler = Arc::new(TrackingHandler::new());
+    let guard = listener.run_handler(handler.clone());
+    let token = reporter.disconnect().unwrap();
+    guard.join(token).unwrap();
+    assert_eq!(handler.handled(), 0);
+    assert!(handler.finished());
+}
+
+#[test]
+fn disconnect_and_join() {
+    let (sender, receiver) = event_channel::<MyEvent>();
+    let reporter = ChannelReporter::new(sender);
+    let listener = ChannelEventListener::new(receiver);
+    let handler = Arc::new(TrackingHandler::new());
+    let guard = listener.run_handler(handler.clone());
+    for i in 0..5 {
+        reporter.report_event(MyEvent(i)).unwrap();
+    }
+    guard.disconnect_and_join(reporter).unwrap();
+    assert_eq!(handler.handled(), 5);
+    assert!(handler.finished());
+}
+
+#[test]
+fn report_event_on_dropped_receiver() {
+    let (sender, receiver) = event_channel::<MyEvent>();
+    let reporter = ChannelReporter::new(sender);
+    drop(receiver);
+    assert!(reporter.report_event(MyEvent(0)).is_err());
+}

--- a/tests/multi_handler.rs
+++ b/tests/multi_handler.rs
@@ -2,15 +2,15 @@
 extern crate core;
 
 use std::marker::PhantomData;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use storyteller::{
     event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
-    EventReporter, FinishProcessing,
+    EventReporter, HandlerGuard,
 };
 
 // Caution: does only check whether `received` events match expected events
-// Must also use `FinalizeHandler::finish_processing` to ensure panic's are caught.
+// Must also use `ChannelHandlerGuard::join` to ensure panic's are caught.
 struct MultiHandler<EventT: Clone> {
     handlers: Vec<Box<dyn EventHandler<Event = EventT>>>,
 }
@@ -36,8 +36,14 @@ impl<EventT: Clone + Sync> EventHandler for MultiHandler<EventT> {
     type Event = EventT;
 
     fn handle(&self, event: Self::Event) {
-        for handle in &self.handlers {
-            handle.handle(event.clone())
+        for handler in &self.handlers {
+            handler.handle(event.clone())
+        }
+    }
+
+    fn finish(&self) {
+        for handler in &self.handlers {
+            handler.finish();
         }
     }
 }
@@ -96,6 +102,39 @@ impl<EventT: Send + Sync + Into<usize>> EventHandler for SummingHandler<EventT> 
     }
 }
 
+struct FinishFlagHandler {
+    finished: Arc<AtomicBool>,
+}
+
+impl EventHandler for FinishFlagHandler {
+    type Event = usize;
+    fn handle(&self, _: Self::Event) {}
+    fn finish(&self) {
+        self.finished.store(true, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn finish_delegates_to_sub_handlers() {
+    let (event_sender, event_receiver) = event_channel::<usize>();
+    let reporter = ChannelReporter::new(event_sender);
+    let listener = ChannelEventListener::new(event_receiver);
+    let flag1 = Arc::new(AtomicBool::new(false));
+    let flag2 = Arc::new(AtomicBool::new(false));
+    let mut multi_handler = MultiHandler::<usize>::new();
+    multi_handler.add_handler(Box::new(FinishFlagHandler {
+        finished: flag1.clone(),
+    }));
+    multi_handler.add_handler(Box::new(FinishFlagHandler {
+        finished: flag2.clone(),
+    }));
+    let fin = listener.run_handler(Arc::new(multi_handler));
+    let token = reporter.disconnect().unwrap();
+    fin.join(token).unwrap();
+    assert!(flag1.load(Ordering::SeqCst));
+    assert!(flag2.load(Ordering::SeqCst));
+}
+
 #[test]
 fn test() {
     let (event_sender, event_receiver) = event_channel::<usize>();
@@ -120,11 +159,11 @@ fn test() {
         reporter.report_event(i).unwrap();
     }
 
-    reporter.disconnect().unwrap();
-    fin.finish_processing().unwrap();
+    let token = reporter.disconnect().unwrap();
+    fin.join(token).unwrap();
 
     // NB: Order of these statements is important. The assertions must be placed after
-    // finish_processing() to ensure all expected events have been processed
+    // join() to ensure all expected events have been processed
     let c1 = unsafe { handler.get_handler::<CountingHandler<usize>>(0) };
     assert_eq!(c1.count(), 5);
 

--- a/tests/registering_handler.rs
+++ b/tests/registering_handler.rs
@@ -4,14 +4,14 @@ extern crate core;
 use std::sync::{Arc, Mutex};
 use storyteller::{
     event_channel, ChannelEventListener, ChannelReporter, EventHandler, EventListener,
-    EventReporter, FinishProcessing,
+    EventReporter, HandlerGuard,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct MyEvent(usize);
 
 // Caution: does only check whether `received` events match expected events
-// Must also use `FinalizeHandler::finish_processing` to ensure panic's are caught.
+// Must also use `ChannelHandlerGuard::join` to ensure panic's are caught.
 struct RegisteringHandler {
     registered_events: Arc<Mutex<Vec<MyEvent>>>,
 }
@@ -54,10 +54,10 @@ fn test() {
         reporter.report_event(MyEvent(i)).unwrap();
     }
 
-    reporter.disconnect().unwrap();
-    fin.finish_processing().unwrap();
+    let token = reporter.disconnect().unwrap();
+    fin.join(token).unwrap();
 
-    // NB: Order is important, must be placed after finish_processing() to ensure all expected
+    // NB: Order is important, must be placed after join() to ensure all expected
     // events have been processed
     let expected = vec![MyEvent(0), MyEvent(1), MyEvent(2), MyEvent(3), MyEvent(4)];
     assert_eq!(handler.events(), expected);
@@ -83,10 +83,10 @@ fn expect_failure(expected_events: Vec<MyEvent>) {
         reporter.report_event(MyEvent(i)).unwrap();
     }
 
-    reporter.disconnect().unwrap();
-    fin.finish_processing().unwrap();
+    let token = reporter.disconnect().unwrap();
+    fin.join(token).unwrap();
 
-    // NB: Order is important, must be placed after finish_processing() to ensure all expected
+    // NB: Order is important, must be placed after join() to ensure all expected
     // events have been processed
     assert_eq!(handler.events(), expected_events);
 }


### PR DESCRIPTION
Calling join before disconnect used to silently deadlock. A new DisconnectToken type, returned by disconnect and required by join, makes the wrong order a compile error. Cloning EventSender could allow the channel to stay open after disconnect preventing the handler thread from ever finishing.

- Rename FinishProcessing to HandlerGuard, finish_processing to join
- Rename ChannelFinalizeHandler to ChannelHandlerGuard.
- Add DisconnectToken returned by disconnect and required by join, making wrong call order a compile error instead of a silent deadlock
- Remove Clone from EventSender
- Panic on drop if ChannelHandlerGuard is not joined
- Add ChannelHandlerGuard::disconnect_and_join shorthand

This pr should make it much harder to do things the wrong way accidentally, something I wanted to work on for a while (years haha).